### PR TITLE
Added setVolume(), setTempo(), mute() and loop mode features

### DIFF
--- a/src/melody_player.cpp
+++ b/src/melody_player.cpp
@@ -211,7 +211,17 @@ void MelodyPlayer::turnOn() {
   // 2000 is a frequency, it will be changed at the first play
   ledcSetup(pwmChannel, 2000, resolution);
   ledcAttachPin(pin, pwmChannel);
-  ledcWrite(pwmChannel, 125);
+  ledcWrite(pwmChannel, volume);
+#endif
+}
+
+void MelodyPlayer::setVolume(byte newVolume) {
+  volume = newVolume;
+#ifdef ESP32
+  if(state == State::PLAY)
+  {
+    ledcWrite(pwmChannel, volume);
+  }
 #endif
 }
 

--- a/src/melody_player.cpp
+++ b/src/melody_player.cpp
@@ -119,6 +119,10 @@ void changeTone(MelodyPlayer* player) {
     { // Loop mode => start over
       player->playAsync();
     }
+    else if(player->stopCallback != NULL)
+    {
+      player->stopCallback();
+    }
   }
 }
 
@@ -136,10 +140,11 @@ void MelodyPlayer::playAsync() {
 #endif
 }
 
-void MelodyPlayer::playAsync(Melody& melody, bool loopMelody) {
+void MelodyPlayer::playAsync(Melody& melody, bool loopMelody, void(*callback)(void)) {
   if (!melody) { return; }
   melodyState = make_unique<MelodyState>(melody);
   loop = loopMelody;
+  stopCallback = callback;
   playAsync();
 }
 

--- a/src/melody_player.cpp
+++ b/src/melody_player.cpp
@@ -86,11 +86,14 @@ void changeTone(MelodyPlayer* player) {
                      + " iteration=" + player->melodyState->getIndex());
 
     if (player->melodyState->isSilence()) {
+      if(!player->muted)
+      {
 #ifdef ESP32
-      ledcWriteTone(player->pwmChannel, 0);
+        ledcWriteTone(player->pwmChannel, 0);
 #else
-      tone(player->pin, 0);
+        tone(player->pin, 0);
 #endif
+      }
 
 #ifdef ESP32
       player->ticker.once_ms(duration, changeTone, player);
@@ -98,12 +101,15 @@ void changeTone(MelodyPlayer* player) {
       player->ticker.once_ms_scheduled(duration, std::bind(changeTone, player));
 #endif
     } else {
+      if(!player->muted)
+      {
 #ifdef ESP32
-      ledcWriteTone(player->pwmChannel, computedNote.frequency);
-      ledcWrite(player->pwmChannel,player->volume);
+        ledcWriteTone(player->pwmChannel, computedNote.frequency);
+        ledcWrite(player->pwmChannel,player->volume);
 #else
-      tone(player->pin, computedNote.frequency);
+        tone(player->pin, computedNote.frequency);
 #endif
+      }
 
 #ifdef ESP32
       player->ticker.once_ms(duration, changeTone, player);
@@ -249,4 +255,15 @@ void MelodyPlayer::turnOff() {
 
   pinMode(pin, OUTPUT);
   digitalWrite(pin, offLevel);
+}
+
+void MelodyPlayer::mute() {
+  muted = true;
+}
+
+void MelodyPlayer::unmute() {
+#ifdef ESP32
+  ledcAttachPin(pin, pwmChannel);
+#endif
+  muted = false;
 }

--- a/src/melody_player.cpp
+++ b/src/melody_player.cpp
@@ -113,7 +113,12 @@ void changeTone(MelodyPlayer* player) {
     }
     player->supportSemiNote = millis() + duration;
   } else {
+    // End of the melody
     player->stop();
+    if(player->loop)
+    { // Loop mode => start over
+      player->playAsync();
+    }
   }
 }
 
@@ -131,9 +136,10 @@ void MelodyPlayer::playAsync() {
 #endif
 }
 
-void MelodyPlayer::playAsync(Melody& melody) {
+void MelodyPlayer::playAsync(Melody& melody, bool loopMelody) {
   if (!melody) { return; }
   melodyState = make_unique<MelodyState>(melody);
+  loop = loopMelody;
   playAsync();
 }
 

--- a/src/melody_player.cpp
+++ b/src/melody_player.cpp
@@ -100,6 +100,7 @@ void changeTone(MelodyPlayer* player) {
     } else {
 #ifdef ESP32
       ledcWriteTone(player->pwmChannel, computedNote.frequency);
+      ledcWrite(player->pwmChannel,player->volume);
 #else
       tone(player->pin, computedNote.frequency);
 #endif
@@ -216,7 +217,7 @@ void MelodyPlayer::turnOn() {
 }
 
 void MelodyPlayer::setVolume(byte newVolume) {
-  volume = newVolume;
+  volume = newVolume/2;
 #ifdef ESP32
   if(state == State::PLAY)
   {

--- a/src/melody_player.cpp
+++ b/src/melody_player.cpp
@@ -267,3 +267,8 @@ void MelodyPlayer::unmute() {
 #endif
   muted = false;
 }
+
+void MelodyPlayer::changeTempo(int newTempo) {
+  if (melodyState == nullptr) { return; }
+  melodyState->changeTempo(newTempo);
+}

--- a/src/melody_player.h
+++ b/src/melody_player.h
@@ -81,6 +81,19 @@ public:
   }
 
   /**
+   * Change the tempo of the current melody to the proided value
+  */
+ void changeTempo(int newTempo);
+
+ /**
+  * Set the volume (0-255 value) of the player (only works on ESP32 platform)
+  * The volume is changed by adjusting the duty-cycle of the pwm signal sent to the piezo
+  * A value of 0 will produce no sound while a value of 255 will set the duty cycle to 50%,
+  * wich will produce the highest possible volume for the piezo.
+ */
+void setVolume(byte volume);
+
+  /**
    * Move the current melody and player's state to the given destination Player.
    * The source player stops and lose the reference to the actual melody (i.e. you have to call
    * play(Melody) to make the source player play again).
@@ -96,6 +109,7 @@ public:
 
 private:
   unsigned char pin;
+  byte volume = 125;
 
 #ifdef ESP32
   unsigned char pwmChannel;

--- a/src/melody_player.h
+++ b/src/melody_player.h
@@ -57,8 +57,9 @@ public:
   /**
    * Play the given melody in asynchronous way (return immediately).
    * If the melody is not valid, this call has no effect.
+   * Set loop to true if you want the melody to start over after at the end.
    */
-  void playAsync(Melody& melody);
+  void playAsync(Melody& melody, bool loop = false);
 
   /**
    * Stop the current melody.
@@ -110,6 +111,7 @@ void setVolume(byte volume);
 private:
   unsigned char pin;
   byte volume = 125;
+  bool loop = false;
 
 #ifdef ESP32
   unsigned char pwmChannel;

--- a/src/melody_player.h
+++ b/src/melody_player.h
@@ -76,6 +76,17 @@ public:
   void pause();
 
   /**
+   * Mute the sound of the current melody without stoppig it
+   * When unmute will be called the melody be resumed
+  */
+  void mute();
+
+  /**
+   * Unmute the current melody
+  */
+  void unmute();
+
+  /**
    * Tell if playing.
    */
   bool isPlaying() const {
@@ -84,16 +95,16 @@ public:
 
   /**
    * Change the tempo of the current melody to the proided value
-  */
- void changeTempo(int newTempo);
+   */
+  void changeTempo(int newTempo);
 
- /**
-  * Set the volume (0-255 value) of the player (only works on ESP32 platform)
-  * The volume is changed by adjusting the duty-cycle of the pwm signal sent to the piezo
-  * A value of 0 will produce no sound while a value of 255 will set the duty cycle to 50%,
-  * wich will produce the highest possible volume for the piezo.
- */
-void setVolume(byte volume);
+  /**
+   * Set the volume (0-255 value) of the player (only works on ESP32 platform)
+   * The volume is changed by adjusting the duty-cycle of the pwm signal sent to the piezo
+   * A value of 0 will produce no sound while a value of 255 will set the duty cycle to 50%,
+   * wich will produce the highest possible volume for the piezo.
+   */
+  void setVolume(byte volume);
 
   /**
    * Move the current melody and player's state to the given destination Player.
@@ -113,6 +124,7 @@ private:
   unsigned char pin;
   byte volume = 125;
   bool loop = false;
+  bool muted = false;
   void (*stopCallback)(void) = NULL;
 
 #ifdef ESP32

--- a/src/melody_player.h
+++ b/src/melody_player.h
@@ -58,8 +58,9 @@ public:
    * Play the given melody in asynchronous way (return immediately).
    * If the melody is not valid, this call has no effect.
    * Set loop to true if you want the melody to start over after at the end.
+   * A call back can be provided to be called at the end of the melody (only used if loop is false)
    */
-  void playAsync(Melody& melody, bool loop = false);
+  void playAsync(Melody& melody, bool loop = false, void(*stopCallback)(void) = NULL);
 
   /**
    * Stop the current melody.
@@ -112,6 +113,7 @@ private:
   unsigned char pin;
   byte volume = 125;
   bool loop = false;
+  void (*stopCallback)(void) = NULL;
 
 #ifdef ESP32
   unsigned char pwmChannel;

--- a/src/melody_player.h
+++ b/src/melody_player.h
@@ -146,9 +146,9 @@ private:
    */
   class MelodyState {
   public:
-    MelodyState() : first(true), index(0), remainingNoteTime(0){};
+    MelodyState() : first(true), index(0), remainingNoteTime(0), timeUnit(0) {};
     MelodyState(const Melody& melody)
-      : melody(melody), first(true), silence(false), index(0), remainingNoteTime(0){};
+      : melody(melody), first(true), silence(false), index(0), remainingNoteTime(0), timeUnit(melody.getTimeUnit()){};
     Melody melody;
 
     unsigned short getIndex() const {
@@ -157,6 +157,10 @@ private:
 
     bool isSilence() const {
       return silence;
+    }
+
+    void changeTempo(int newTempo) {
+      timeUnit = (60 * 1000 * 4 / newTempo / 32);
     }
 
     /**
@@ -222,7 +226,7 @@ private:
      */
     NoteDuration getCurrentComputedNote() const {
       NoteDuration note = melody.getNote(getIndex());
-      note.duration = melody.getTimeUnit() * note.duration;
+      note.duration = timeUnit * note.duration;
       // because the fixed point notation
       note.duration /= 2;
       return note;
@@ -232,6 +236,7 @@ private:
     bool first;
     bool silence;
     unsigned short index;
+    unsigned short timeUnit;
 
     /**
      * Variable to support precise pauses and move/duplicate melodies between Players.


### PR DESCRIPTION
Hi Fabiano,

I'm working on a Tetris game for Awtrix/Ulanzi desktop clock (https://github.com/fredzo/awtris) and I've been in need of some new features in your great melody-player library !
Here is a PR with this new features : 
- new playAsync() parameters to allow loop mode on current melody and callback function to be called at the end of the melody 
- new setVolume() method to change piezo duty-cycle on ESP32 platform to adapt music volume
- new setTempo() method to change the tempo of current melody
- new mute() method that allows muting the melody while playing a sound effect, for example, with another player (on the same pin) and go back to the melody afterwards

Please let me know if you have any comment or need any change.

Best regards,

Frederic.