### PR TITLE
Update for newer IDF Arduino core

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Melody Player
+# Melody Player for ESP
 
-[![arduino-library-badge](https://www.ardu-badge.com/badge/Melody%20Player.svg)](https://www.ardu-badge.com/Melody%20Player) ![Compile Library Examples](https://github.com/fabianoriccardi/melody-player/actions/workflows/LibraryBuild.yml/badge.svg)
+[![arduino-library-badge](https://www.ardu-badge.com/badge/Melody%20Player.svg)](https://www.ardu-badge.com/badge/Melody%20Player.svg) ![Compile Library Examples](https://github.com/fabiuz7/melody-player-arduino/actions/workflows/LibraryBuild.yml/badge.svg)
 
 Melody Player is an Arduino library to play melodies on buzzers on ESP8266 and ESP32 in a non-blocking manner. Melodies can be written directly in code or loaded from file. It supports Ring Tone Text Transfer Language (RTTTL) format and a custom format developed specifically to enjoy all the benefits of this library.
 
@@ -100,5 +100,4 @@ Example 2: the same melody using the "integer" codification:
 
 ## Useful links
 
-* <https://panuworld.net/nuukiaworld/download/nokix/rtttl.htm>: RTTTL specification
 * <https://adamonsoon.github.io/rtttl-play/>: Test and listen RTTTL melodies

--- a/examples/4_load_rtttl_melody/4_load_rtttl_melody.ino
+++ b/examples/4_load_rtttl_melody/4_load_rtttl_melody.ino
@@ -9,7 +9,6 @@
 int buzzerPin = 4;
 
 String melodyFilePath = "/pokemon.rtttl";
-String DBFilePath = "/RingTones.RTTTL.txt";
 
 const char melodyString[] = "Pokemon:d=16,o=5,b=112:32p,f,a#,c6,c#6,c6,c#6,d#6,2f6,a#,c6,8c#6,8f6,"
                             "8d#6,32c#.6,32d#.6,32c#.6,8c6,8g#.,f,a#,c6,c#6,c6,c#6,d#6,2f6,8a#,c#6,"
@@ -29,9 +28,7 @@ void setup() {
   Melody melody = MelodyFactory.loadRtttlString(melodyString);
   if (melody) {
     Serial.println("Done!");
-    Serial.print("Playing ");
-    Serial.print(melody.getTitle());
-    Serial.print("... ");
+    Serial.print("Playing... ");
     player.play(melody);
     Serial.println("Done!");
   } else {
@@ -50,26 +47,7 @@ void setup() {
     Serial.println("Error");
   } else {
     Serial.println("Done!");
-
-    Serial.print("Playing ");
-    Serial.print(melody.getTitle());
-    Serial.print("... ");
-    player.play(melody);
-    Serial.println("Done!");
-  }
-
-  delay(1000);
-  Serial.println();
-
-  Serial.print("Loading melody from DB... ");
-  melody = MelodyFactory.loadRtttlDB(DBFilePath, "Axel");
-  if (!melody) {
-    Serial.println("Error");
-  } else {
-    Serial.println("Done!");
-    Serial.print("Playing ");
-    Serial.print(melody.getTitle());
-    Serial.print("... ");
+    Serial.print("Playing... ");
     player.play(melody);
     Serial.println("Done!");
   }

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "Melody Player",
-  "version": "2.4.0",
+  "version": "2.3.1",
   "authors": {
     "name": "Fabiano Riccardi",
     "email": "fabiano.riccardi@outlook.com"

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=Melody Player
-version=2.4.0
-author=Fabiano Riccardi <fabiano.riccardi@outlook.com>
-maintainer=Fabiano Riccardi <fabiano.riccardi@outlook.com>
-sentence=This library provides an intuitive interface to play melodies on buzzers
-paragraph=The melodies can be stored in file systems (SPIFFS or LittleFS) or hardcoded in your sketch. Support RTTTL.
+version=3.0.0
+author=OpenBuilds
+maintainer=OpenBuilds <support@openbuilds.com>
+sentence=This library provides an intuitive interface to play melodies on buzzers. Based on Fabiano Riccardi's library. Updated for use with ESP Arduino V3.x
+paragraph=The melodies can be stored in file systems (SPIFFS or LittleFS) or hardcoded in your sketch. Support RTTTL. Based on Fabiano Riccardi's library. Updated for use with ESP Arduino V3.x
 category=Device Control
-url=https://github.com/fabianoriccardi/melody-player
+url=https://github.com/openbuilds/melody-player
 architectures=esp8266,esp32

--- a/src/melody_factory.h
+++ b/src/melody_factory.h
@@ -35,15 +35,9 @@ public:
   Melody load(String filePath, FS& fs = SPIFFS);
 
   /**
-   * Load melody from file in RTTTL format. The file must contain only one melody.
+   * Load melody from file in RTTTL format.
    */
   Melody loadRtttlFile(String filePath, FS& fs = SPIFFS);
-
-  /**
-   * Load melody with the given title from a file containing multiple RTTTL melody (one Melody per
-   * line).
-   */
-  Melody loadRtttlDB(String filepath, String title, FS& fs = SPIFFS);
 
   /**
    * Load melody from string in RTTTL format.

--- a/src/melody_factory_rtttl.cpp
+++ b/src/melody_factory_rtttl.cpp
@@ -126,54 +126,6 @@ Melody MelodyFactoryClass::loadRtttlFile(String filepath, FS& fs) {
   return Melody();
 }
 
-Melody MelodyFactoryClass::loadRtttlDB(String filepath, String title, FS& fs) {
-  File f = fs.open(filepath, "r");
-  f.setTimeout(0);
-
-  if (!f) {
-    if (debug) Serial.println("Opening file error");
-    return Melody();
-  }
-
-  if (title.length() == 0) {
-    if (debug) Serial.println("Title length = 0");
-    return Melody();
-  }
-
-  if (!f.find(title.c_str())) {
-    if (debug) Serial.println("Unable to find melody with title: " + String(title));
-    return Melody();
-  }
-  f.readStringUntil(':');
-
-  String values = f.readStringUntil(':');
-  values.trim();
-  if (debug) Serial.println(String("Default values:") + values);
-  if (values.length() == 0) { return Melody(); }
-
-  parseDefaultValues(values);
-
-  // 32 because it is the shortest note!
-  int timeUnit = 60 * 1000 * 4 / beat / 32;
-
-  size_t position = f.position();
-  int bytesUntilNewLine = f.readStringUntil('\n').length();
-  f.seek(position);
-
-  notes = std::make_shared<std::vector<NoteDuration>>();
-  bool result = true;
-  while (f.available() && notes->size() < maxLength && result && bytesUntilNewLine > 0) {
-    String s = f.readStringUntil(',');
-    if (s.length() > bytesUntilNewLine) { s = s.substring(0, bytesUntilNewLine); }
-    bytesUntilNewLine -= s.length() + 1;
-    s.trim();
-    result = parseRtttlNote(s);
-  }
-  if (result && notes->size() > 0) { return Melody(title, timeUnit, notes, false); }
-
-  return Melody();
-}
-
 Melody MelodyFactoryClass::loadRtttlString(const char rtttlMelody[]) {
   String title;
   int i = 0;

--- a/src/melody_player.cpp
+++ b/src/melody_player.cpp
@@ -40,14 +40,14 @@ void MelodyPlayer::play() {
                      + " duration:" + computedNote.duration);
     if (melodyState->isSilence()) {
 #ifdef ESP32
-      ledcWriteTone(pwmChannel, 0);
+      ledcWriteTone(pin, 0);
 #else
       noTone(pin);
 #endif
       delay(0.3f * computedNote.duration);
     } else {
 #ifdef ESP32
-      ledcWriteTone(pwmChannel, computedNote.frequency);
+      ledcWriteTone(pin, computedNote.frequency);
 #else
       tone(pin, computedNote.frequency);
 #endif
@@ -87,7 +87,7 @@ void changeTone(MelodyPlayer* player) {
 
     if (player->melodyState->isSilence()) {
 #ifdef ESP32
-      ledcWriteTone(player->pwmChannel, 0);
+      ledcWriteTone(player->pin, 0);
 #else
       tone(player->pin, 0);
 #endif
@@ -99,7 +99,7 @@ void changeTone(MelodyPlayer* player) {
 #endif
     } else {
 #ifdef ESP32
-      ledcWriteTone(player->pwmChannel, computedNote.frequency);
+      ledcWriteTone(player->pin, computedNote.frequency);
 #else
       tone(player->pin, computedNote.frequency);
 #endif
@@ -186,8 +186,8 @@ void MelodyPlayer::duplicateMelodyTo(MelodyPlayer& destPlayer) {
 }
 
 #ifdef ESP32
-MelodyPlayer::MelodyPlayer(unsigned char pin, unsigned char pwmChannel, bool offLevel)
-  : pin(pin), pwmChannel(pwmChannel), offLevel(offLevel), state(State::STOP), melodyState(nullptr) {
+MelodyPlayer::MelodyPlayer(unsigned char pin, bool offLevel)
+  : pin(pin), offLevel(offLevel), state(State::STOP), melodyState(nullptr) {
   pinMode(pin, OUTPUT);
   digitalWrite(pin, offLevel);
 };
@@ -209,16 +209,14 @@ void MelodyPlayer::turnOn() {
 #ifdef ESP32
   const int resolution = 8;
   // 2000 is a frequency, it will be changed at the first play
-  ledcSetup(pwmChannel, 2000, resolution);
-  ledcAttachPin(pin, pwmChannel);
-  ledcWrite(pwmChannel, 125);
+  ledcAttach(pin, 2000, resolution);
+  ledcWrite(pin, 125);
 #endif
 }
 
 void MelodyPlayer::turnOff() {
 #ifdef ESP32
-  ledcWrite(pwmChannel, 0);
-  ledcDetachPin(pin);
+  analogWrite(pin, 0);
 #else
   // Remember that this will set LOW output, it doesn't mean that buzzer is off (look at offLevel
   // for more info).

--- a/src/melody_player.h
+++ b/src/melody_player.h
@@ -27,11 +27,7 @@
 class MelodyPlayer {
 public:
 #ifdef ESP32
-  /**
-   * pwmChannel is optional and you have to configure it only if you play will
-   * simultaneous melodies.
-   */
-  MelodyPlayer(unsigned char pin, unsigned char pwmChannel = 0, bool offLevel = HIGH);
+  MelodyPlayer(unsigned char pin, bool offLevel = HIGH);
 #else
   MelodyPlayer(unsigned char pin, bool offLevel = HIGH);
 #endif


### PR DESCRIPTION
Could no longer compile against newer Arduino cores because of https://docs.espressif.com/projects/arduino-esp32/en/latest/migration_guides/2.x_to_3.0.html

I fixed LEDC and LEDC Channel sections, newer IDF automatically assigns channels, and has little different syntax.  Tested OK on https://github.com/espressif/arduino-esp32 V3.1.1 